### PR TITLE
Implement semantic search storage layer

### DIFF
--- a/semantic_search/__init__.py
+++ b/semantic_search/__init__.py
@@ -1,0 +1,10 @@
+import logging
+
+# Configure logging similar to other modules in this repository.  This ensures
+# that when the package is imported directly, users see helpful information
+# about what the code is doing.
+if not logging.getLogger().handlers:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )

--- a/semantic_search/config/default_config.yaml
+++ b/semantic_search/config/default_config.yaml
@@ -1,0 +1,5 @@
+# Default configuration for semantic search
+root_path: /path/to/business-os
+file_extensions: ['.md', '.txt', '.py']
+embedding_model: nomic-embed-text
+llm_provider: ollama

--- a/semantic_search/interfaces/__init__.py
+++ b/semantic_search/interfaces/__init__.py
@@ -1,0 +1,1 @@
+"""User interfaces for semantic search."""

--- a/semantic_search/requirements.txt
+++ b/semantic_search/requirements.txt
@@ -1,0 +1,2 @@
+# Optional dependencies for full functionality
+faiss-cpu

--- a/semantic_search/storage/__init__.py
+++ b/semantic_search/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage layer for semantic search."""

--- a/semantic_search/storage/faiss_manager.py
+++ b/semantic_search/storage/faiss_manager.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import pickle
+import math
+from typing import List, Iterable, Tuple, Dict
+
+# In a production setting we would use the FAISS library for fast vector
+# similarity search. Since this environment may not have FAISS available, this
+# module provides a lightweight stand-in that mimics the basic API using pure
+# Python data structures.
+
+
+def init_index(dim: int) -> Dict:
+    """Create an empty index structure.
+
+    Parameters
+    ----------
+    dim : int
+        Dimensionality of the embedding vectors.
+    """
+    return {"dim": dim, "vectors": [], "ids": []}
+
+
+def add_vectors(index: Dict, vectors: Iterable[Iterable[float]], ids: Iterable[int]) -> None:
+    """Add embeddings to the in-memory index."""
+    for vec, i in zip(vectors, ids):
+        index["vectors"].append(list(vec))
+        index["ids"].append(i)
+
+
+def search(index: Dict, vector: Iterable[float], k: int = 5) -> Tuple[List[int], List[float]]:
+    """Return IDs of the closest vectors using Euclidean distance."""
+    dists = []
+    for idx, vec in zip(index["ids"], index["vectors"]):
+        dist = math.sqrt(sum((a - b) ** 2 for a, b in zip(vec, vector)))
+        dists.append((dist, idx))
+    dists.sort(key=lambda x: x[0])
+    top = dists[:k]
+    ids = [i for _, i in top]
+    scores = [d for d, _ in top]
+    return ids, scores
+
+
+def save_index(index: Dict, path: str) -> None:
+    """Persist the index to disk using pickle."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "wb") as fh:
+        pickle.dump(index, fh)
+
+
+def load_index(path: str) -> Dict:
+    """Load an index from disk."""
+    with open(path, "rb") as fh:
+        return pickle.load(fh)

--- a/semantic_search/storage/metadata_db.py
+++ b/semantic_search/storage/metadata_db.py
@@ -1,0 +1,125 @@
+import sqlite3
+from pathlib import Path
+from datetime import datetime
+from typing import Iterable, Tuple, List, Dict, Optional
+
+# Schema definition for SQLite database. We store file information and text
+# chunks. Each chunk references the file it belongs to.
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS files(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    path TEXT UNIQUE,
+    size INTEGER,
+    mtime REAL
+);
+
+CREATE TABLE IF NOT EXISTS chunks(
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    file_id INTEGER,
+    chunk_index INTEGER,
+    text TEXT,
+    FOREIGN KEY(file_id) REFERENCES files(id)
+);
+"""
+
+
+def init_db(db_path: str) -> sqlite3.Connection:
+    """Create a SQLite database and required tables.
+
+    Parameters
+    ----------
+    db_path: str
+        Path to the SQLite database file.
+
+    Returns
+    -------
+    sqlite3.Connection
+        Connection object to the initialized database.
+    """
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.executescript(SCHEMA)
+    conn.commit()
+    return conn
+
+
+def add_file_metadata(conn: sqlite3.Connection, path: str, size: int, mtime: float) -> int:
+    """Insert or update file metadata.
+
+    The function returns the database ID for the file. If the file already
+    exists in the database, its ID is returned without modification.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT OR IGNORE INTO files(path, size, mtime) VALUES (?, ?, ?)",
+        (path, size, mtime),
+    )
+    conn.commit()
+    cur.execute("SELECT id FROM files WHERE path = ?", (path,))
+    file_id = cur.fetchone()[0]
+    return file_id
+
+
+def add_chunk_metadata(
+    conn: sqlite3.Connection,
+    file_id: int,
+    chunk_index: int,
+    text: str,
+) -> int:
+    """Store chunk text for a given file.
+
+    Parameters
+    ----------
+    conn : sqlite3.Connection
+        Database connection.
+    file_id : int
+        ID of the parent file from the `files` table.
+    chunk_index : int
+        Sequential index of the chunk within the file.
+    text : str
+        Text content of the chunk.
+
+    Returns
+    -------
+    int
+        ID of the inserted chunk.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO chunks(file_id, chunk_index, text) VALUES (?, ?, ?)",
+        (file_id, chunk_index, text),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def query_by_date_range(
+    conn: sqlite3.Connection,
+    start: datetime,
+    end: datetime,
+) -> List[Dict[str, Optional[str]]]:
+    """Retrieve files modified within the specified date range."""
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, path, size, mtime FROM files WHERE mtime BETWEEN ? AND ?",
+        (start.timestamp(), end.timestamp()),
+    )
+    rows = cur.fetchall()
+    return [
+        {
+            "id": r[0],
+            "path": r[1],
+            "size": r[2],
+            "mtime": r[3],
+        }
+        for r in rows
+    ]
+
+
+def get_chunk_by_id(conn: sqlite3.Connection, chunk_id: int) -> Optional[str]:
+    """Return the text of a chunk by its ID."""
+    cur = conn.cursor()
+    cur.execute("SELECT text FROM chunks WHERE id = ?", (chunk_id,))
+    row = cur.fetchone()
+    return row[0] if row else None

--- a/semantic_search/tests/__init__.py
+++ b/semantic_search/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the semantic search package."""

--- a/semantic_search/tests/test_faiss_manager.py
+++ b/semantic_search/tests/test_faiss_manager.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+
+from semantic_search.storage.faiss_manager import (
+    init_index,
+    add_vectors,
+    search,
+    save_index,
+    load_index,
+)
+
+
+class TestFaissManager(unittest.TestCase):
+    def setUp(self):
+        self.index_path = 'tmp_index.pkl'
+        if os.path.exists(self.index_path):
+            os.remove(self.index_path)
+        self.index = init_index(3)
+
+    def tearDown(self):
+        if os.path.exists(self.index_path):
+            os.remove(self.index_path)
+
+    def test_add_search_save_load(self):
+        add_vectors(self.index, [[1, 0, 0], [0, 1, 0]], [1, 2])
+        ids, scores = search(self.index, [1, 0, 0], k=1)
+        self.assertEqual(ids[0], 1)
+
+        save_index(self.index, self.index_path)
+        loaded = load_index(self.index_path)
+        ids_loaded, _ = search(loaded, [0, 1, 0], k=1)
+        self.assertEqual(ids_loaded[0], 2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/semantic_search/tests/test_metadata_db.py
+++ b/semantic_search/tests/test_metadata_db.py
@@ -1,0 +1,41 @@
+import os
+import unittest
+from datetime import datetime, timedelta
+
+from semantic_search.storage.metadata_db import (
+    init_db,
+    add_file_metadata,
+    add_chunk_metadata,
+    query_by_date_range,
+    get_chunk_by_id,
+)
+
+
+class TestMetadataDB(unittest.TestCase):
+    def setUp(self):
+        self.db_path = 'tmp_test.db'
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+        self.conn = init_db(self.db_path)
+
+    def tearDown(self):
+        self.conn.close()
+        if os.path.exists(self.db_path):
+            os.remove(self.db_path)
+
+    def test_add_and_query(self):
+        file_id = add_file_metadata(self.conn, 'file.txt', 100, datetime.now().timestamp())
+        chunk_id = add_chunk_metadata(self.conn, file_id, 0, 'hello world')
+
+        start = datetime.now() - timedelta(days=1)
+        end = datetime.now() + timedelta(days=1)
+        files = query_by_date_range(self.conn, start, end)
+        self.assertEqual(len(files), 1)
+        self.assertEqual(files[0]['id'], file_id)
+
+        text = get_chunk_by_id(self.conn, chunk_id)
+        self.assertEqual(text, 'hello world')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/semantic_search/utils/__init__.py
+++ b/semantic_search/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility functions for semantic search."""


### PR DESCRIPTION
## Summary
- add package skeleton for `semantic_search`
- implement SQLite metadata database helpers
- implement simple FAISS-like vector store
- provide default config and requirements
- add unit tests for storage layer

## Testing
- `python -m pytest semantic_search/tests`